### PR TITLE
[Hashing] Update `FailedHashes` to contain the actual failed hash

### DIFF
--- a/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/VerifiableStreamProvider.kt
+++ b/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/VerifiableStreamProvider.kt
@@ -2,6 +2,7 @@ package net.navatwo.kaff4.model
 
 import net.navatwo.kaff4.model.rdf.Aff4RdfModel
 import net.navatwo.kaff4.model.rdf.Hash
+import okio.ByteString
 import okio.Timeout
 
 interface VerifiableStreamProvider {
@@ -22,8 +23,16 @@ interface VerifiableStreamProvider {
     data class FailedHash(
       val stream: Aff4RdfModel,
       val name: String,
-      val hash: Hash,
-    )
+      val expectedHash: Hash,
+      val actualHash: Hash,
+    ) {
+      constructor(
+        stream: Aff4RdfModel,
+        name: String,
+        expectedHash: Hash,
+        actualHash: ByteString,
+      ) : this(stream, name, expectedHash, expectedHash.hashType.value(actualHash))
+    }
 
     companion object {
       fun fromFailedHashes(failureReasons: Collection<FailedHash>): Result = if (failureReasons.isNotEmpty()) {

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/BevyIndexReader.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/BevyIndexReader.kt
@@ -62,7 +62,7 @@ internal class BevyIndexReader @AssistedInject constructor(
       position = indexFilePosition
     }
 
-    if (!bufferArray.hasRemaining()) {
+    if (bufferArray.remaining() < IndexValue.SIZE_BYTES) {
       val source = currentSource ?: run {
         val nextSource = fileSystem.source(bevy.indexSegment).buffer()
         currentSource = nextSource

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/RealAff4ImageStreamSourceProvider.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/RealAff4ImageStreamSourceProvider.kt
@@ -82,15 +82,15 @@ internal class RealAff4ImageStreamSourceProvider @AssistedInject constructor(
   }
 
   private fun verifyLinearHashes(timeout: Timeout): Sequence<FailedHash> = sequence {
+    val linearHashesByHashType = imageStream.linearHashes.associateBy { it.hashType }
     val calculatedLinearHashes = use(timeout = timeout) { s ->
-      s.computeLinearHashes(imageStream.linearHashes.map { it.hashType })
+      s.computeLinearHashes(linearHashesByHashType.keys)
     }
 
-    val linearHashesByHashType = imageStream.linearHashes.associateBy { it.hashType }
     for ((hashType, actualHash) in calculatedLinearHashes) {
       val expectedHash = linearHashesByHashType.getValue(hashType)
       if (expectedHash.value != actualHash) {
-        yield(FailedHash(imageStream, "Linear", expectedHash))
+        yield(FailedHash(imageStream, "Linear", expectedHash, actualHash))
       }
     }
   }
@@ -118,7 +118,9 @@ internal class RealAff4ImageStreamSourceProvider @AssistedInject constructor(
       }
 
       if (blockHash.hash.value != actualHash) {
-        yield(FailedHash(imageStream, "BlockHash ${blockHash.forHashType}", blockHash.hash))
+        yield(
+          FailedHash(imageStream, "BlockHash ${blockHash.forHashType}", blockHash.hash, actualHash)
+        )
       }
     }
   }

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/zip_segment/RealAff4ZipSegmentSourceProvider.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/zip_segment/RealAff4ZipSegmentSourceProvider.kt
@@ -49,7 +49,7 @@ internal class RealAff4ZipSegmentSourceProvider @AssistedInject constructor(
       for (expectedHash in zipSegment.linearHashes) {
         val actualHash = actualLinearHashes.getValue(expectedHash.hashType)
         if (expectedHash.value != actualHash) {
-          failedHashes += FailedHash(zipSegment, "Linear", expectedHash)
+          failedHashes += FailedHash(zipSegment, "Linear", expectedHash, actualHash)
         }
       }
 


### PR DESCRIPTION
Previously, we only surfaced the expected hash in failures. This now surfaces both the expected and actual hashes.