### PR TITLE
[Compression] Add documentation and requirements for `CompressionMethod`

### DIFF
--- a/kaff4-compression/kaff4-compression-snappy/build.gradle.kts
+++ b/kaff4-compression/kaff4-compression-snappy/build.gradle.kts
@@ -11,4 +11,9 @@ dependencies {
   implementation("org.xerial.snappy:snappy-java:1.1.8.4")
 
   implementation(project(":kaff4-core:kaff4-core-guice"))
+
+  testImplementation(project(":kaff4-compression:kaff4-compression-test"))
+  testImplementation(project(":kaff4-core:kaff4-core-test"))
 }
+
+useJunit5()

--- a/kaff4-compression/kaff4-compression-snappy/src/test/kotlin/net/navatwo/kaff4/streams/compression/SnappyCompressionTest.kt
+++ b/kaff4-compression/kaff4-compression-snappy/src/test/kotlin/net/navatwo/kaff4/streams/compression/SnappyCompressionTest.kt
@@ -1,0 +1,24 @@
+package net.navatwo.kaff4.streams.compression
+
+import net.navatwo.test.GuiceModule
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+class SnappyCompressionTest : BaseCompressionMethodTest() {
+  @GuiceModule
+  val testModule = Aff4SnappyPlugin
+
+  @Inject
+  override lateinit var compressionMethod: SnappyCompression
+
+  override val compressedDataValues = CompressedDataValues(
+    compressedSize = 484,
+    md5 = "deec7e31e44503f4a685a38780e29ba1",
+  )
+
+  @Test
+  fun `method == IDENTIFIER`() {
+    Assertions.assertThat(compressionMethod.method).isEqualTo(SnappyCompression.IDENTIFIER)
+  }
+}

--- a/kaff4-compression/kaff4-compression-test/build.gradle.kts
+++ b/kaff4-compression/kaff4-compression-test/build.gradle.kts
@@ -1,0 +1,13 @@
+dependencies {
+  implementation(kotlin("stdlib-jdk8"))
+
+  api(project(":kaff4-core:kaff4-core-model:kaff4-core-model-api"))
+
+  api(Dependencies.JUNIT_JUIPTER_API)
+
+  implementation(project(":kaff4-compression"))
+  implementation(project(":kaff4-core:kaff4-core-test"))
+
+  implementation(Dependencies.ASSERTJ_CORE)
+  implementation(Dependencies.OKIO)
+}

--- a/kaff4-compression/kaff4-compression-test/src/main/kotlin/net/navatwo/kaff4/streams/compression/BaseCompressionMethodTest.kt
+++ b/kaff4-compression/kaff4-compression-test/src/main/kotlin/net/navatwo/kaff4/streams/compression/BaseCompressionMethodTest.kt
@@ -1,0 +1,85 @@
+package net.navatwo.kaff4.streams.compression
+
+import net.navatwo.kaff4.io.md5
+import net.navatwo.kaff4.io.repeatByteString
+import net.navatwo.kaff4.model.rdf.CompressionMethod
+import net.navatwo.kaff4.model.rdf.CompressionMethod.Companion.NOT_UNCOMPRESSED_SENTINEL_VALUE
+import net.navatwo.kaff4.streams.compression.ByteBuffers.markAndReset
+import okio.ByteString.Companion.toByteString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+@Suppress("FunctionNaming", "MagicNumber")
+abstract class BaseCompressionMethodTest protected constructor() {
+  protected abstract val compressionMethod: CompressionMethod
+
+  protected abstract val compressedDataValues: CompressedDataValues
+
+  data class CompressedDataValues(
+    val compressedSize: Int,
+    val md5: String,
+  )
+
+  @Test
+  fun `compress and decompress round trip`() {
+    val inputSize = 1024 * 10
+    val byteString = 1.repeatByteString(inputSize)
+    val uncompressedByteBuffer = ByteBuffer.allocateDirect(inputSize).apply {
+      put(byteString.toByteArray())
+      rewind()
+    }
+
+    val compressedSize = compressedDataValues.compressedSize
+
+    val compressedByteBuffer = ByteBuffer.allocateDirect(10 + compressedSize.coerceAtMost(inputSize * 5))
+
+    // Write into an offset
+    val compressionWriteOffset = 5
+    compressedByteBuffer.position(compressionWriteOffset)
+
+    assertThat(compressionMethod.compress(uncompressedByteBuffer, compressedByteBuffer))
+      .isEqualTo(compressedSize)
+
+    assertThat(uncompressedByteBuffer.position()).isZero()
+    assertThat(compressedByteBuffer.position()).isEqualTo(compressionWriteOffset)
+
+    // It's not full
+    compressedByteBuffer.limit(compressedSize + compressionWriteOffset)
+
+    compressedByteBuffer.markAndReset {
+      assertThat(compressedByteBuffer.toByteString()).md5(compressedDataValues.md5)
+    }
+
+    val uncompressedRoundTripBuffer = ByteBuffer.allocateDirect(inputSize * 3 / 2)
+    val uncompressedRoundTripBufferOffset = 2
+    uncompressedRoundTripBuffer.position(uncompressedRoundTripBufferOffset)
+
+    assertThat(compressionMethod.uncompress(compressedByteBuffer, uncompressedRoundTripBuffer))
+      .isEqualTo(inputSize)
+
+    assertThat(compressedByteBuffer.position()).isEqualTo(compressionWriteOffset)
+    assertThat(uncompressedRoundTripBuffer.position()).isEqualTo(uncompressedRoundTripBufferOffset)
+
+    uncompressedRoundTripBuffer.limit(inputSize + uncompressedRoundTripBufferOffset)
+    assertThat(uncompressedRoundTripBuffer.toByteString()).isEqualTo(byteString)
+  }
+
+  @Test
+  fun `decompress uncompressed data returns zero`() {
+    val inputSize = 20 * 10
+    val byteString = 1.repeatByteString(inputSize)
+
+    val uncompressedByteBuffer = ByteBuffer.allocateDirect(byteString.size).apply {
+      put(byteString.toByteArray())
+      rewind()
+    }
+    val outputByteBuffer = ByteBuffer.allocateDirect(inputSize * 2)
+
+    assertThat(compressionMethod.uncompress(uncompressedByteBuffer, outputByteBuffer))
+      .isEqualTo(NOT_UNCOMPRESSED_SENTINEL_VALUE)
+
+    assertThat(uncompressedByteBuffer.position()).isZero()
+    assertThat(outputByteBuffer.position()).isZero()
+  }
+}

--- a/kaff4-compression/kaff4-compression-test/src/main/kotlin/net/navatwo/kaff4/streams/compression/BaseCompressionMethodTest.kt
+++ b/kaff4-compression/kaff4-compression-test/src/main/kotlin/net/navatwo/kaff4/streams/compression/BaseCompressionMethodTest.kt
@@ -10,13 +10,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 
+// This is a test, these are normally ignored
 @Suppress("FunctionNaming", "MagicNumber")
 abstract class BaseCompressionMethodTest protected constructor() {
+  /** Compression method under test */
   protected abstract val compressionMethod: CompressionMethod
 
+  /** Data values used for [compress and decompress round trip] */
   protected abstract val compressedDataValues: CompressedDataValues
 
-  data class CompressedDataValues(
+  protected data class CompressedDataValues(
     val compressedSize: Int,
     val md5: String,
   )

--- a/kaff4-compression/src/main/kotlin/net/navatwo/kaff4/streams/compression/ByteBuffers.kt
+++ b/kaff4-compression/src/main/kotlin/net/navatwo/kaff4/streams/compression/ByteBuffers.kt
@@ -1,0 +1,25 @@
+package net.navatwo.kaff4.streams.compression
+
+import java.nio.ByteBuffer
+
+object ByteBuffers {
+  inline fun <R> markAndReset(vararg byteBuffers: ByteBuffer, block: () -> R): R {
+    val positions = byteBuffers.associateWith { it.position() }
+    return try {
+      block()
+    } finally {
+      for ((buffer, pos) in positions) {
+        buffer.position(pos)
+      }
+    }
+  }
+
+  inline fun <R> ByteBuffer.markAndReset(block: () -> R): R {
+    val pos = position()
+    return try {
+      block()
+    } finally {
+      position(pos)
+    }
+  }
+}

--- a/kaff4-core/kaff4-core-model/kaff4-core-model-api/src/main/kotlin/net/navatwo/kaff4/model/rdf/CompressionMethod.kt
+++ b/kaff4-core/kaff4-core-model/kaff4-core-model-api/src/main/kotlin/net/navatwo/kaff4/model/rdf/CompressionMethod.kt
@@ -5,15 +5,52 @@ import java.nio.ByteBuffer
 interface CompressionMethod {
   val method: String?
 
+  /**
+   * Checks if [compressed] stores compressed data.
+   *
+   * @return true if compressed.
+   *
+   * **Note:** [compressed] is always reset to it's original state.
+   */
+  fun isCompressed(compressed: ByteBuffer): Boolean
+
+  /**
+   * Attempts to compress [source] into [destination]
+   *
+   * If unable to compress, returning [NOT_COMPRESSED_SENTINEL_VALUE] will cause the data to always be ignored.
+   *
+   * **Note:** [source] and [destination] are always reset to their original states.
+   *
+   * @return The byte size of the now compressed data in [destination].
+   */
   fun compress(
-    uncompressed: ByteBuffer,
-    compressed: ByteBuffer,
+    source: ByteBuffer,
+    destination: ByteBuffer,
   ): Int
 
+  /**
+   * Attempts to uncompress [source] into [destination].
+   *
+   * If unable to uncompress, will return [NOT_UNCOMPRESSED_SENTINEL_VALUE].
+   *
+   * **Note:** [source] and [destination] are always reset to their original states.
+   *
+   * @return The byte size of the uncompressed data.
+   */
   fun uncompress(
-    compressed: ByteBuffer,
-    uncompressed: ByteBuffer,
+    source: ByteBuffer,
+    destination: ByteBuffer,
   ): Int
 
-  companion object
+  companion object {
+    /**
+     * Value returned by implementations when unable to [compress] data.
+     */
+    const val NOT_COMPRESSED_SENTINEL_VALUE: Int = Int.MAX_VALUE
+
+    /**
+     * Value returned by implementations when unable to [uncompress] data.
+     */
+    const val NOT_UNCOMPRESSED_SENTINEL_VALUE: Int = 0
+  }
 }

--- a/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/NoneCompressionMethod.kt
+++ b/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/NoneCompressionMethod.kt
@@ -1,36 +1,20 @@
 package net.navatwo.kaff4.model.rdf
 
+import net.navatwo.kaff4.model.rdf.CompressionMethod.Companion.NOT_COMPRESSED_SENTINEL_VALUE
+import net.navatwo.kaff4.model.rdf.CompressionMethod.Companion.NOT_UNCOMPRESSED_SENTINEL_VALUE
 import java.nio.ByteBuffer
 
 internal object NoneCompressionMethod : CompressionMethod {
+
   override val method: String? = null
 
-  override fun compress(uncompressed: ByteBuffer, compressed: ByteBuffer): Int {
-    return copyAndTruncate(uncompressed, compressed)
-  }
+  override fun isCompressed(compressed: ByteBuffer): Boolean = false
 
-  override fun uncompress(compressed: ByteBuffer, uncompressed: ByteBuffer): Int {
-    return copyAndTruncate(compressed, uncompressed)
-  }
+  override fun compress(source: ByteBuffer, destination: ByteBuffer): Int = NOT_COMPRESSED_SENTINEL_VALUE
+
+  override fun uncompress(source: ByteBuffer, destination: ByteBuffer): Int = NOT_UNCOMPRESSED_SENTINEL_VALUE
 
   override fun toString(): String = javaClass.simpleName
-
-  private fun copyAndTruncate(src: ByteBuffer, dst: ByteBuffer): Int {
-    check(dst.remaining() >= src.remaining()) {
-      "dst buffer does not have enough remaining [${dst.remaining()}] require [${src.remaining()}]"
-    }
-
-    val srcRemaining = src.remaining()
-
-    dst.mark()
-    src.mark()
-
-    dst.put(src)
-
-    dst.reset()
-    src.reset()
-    return srcRemaining
-  }
 }
 
 val CompressionMethod.Companion.None: CompressionMethod

--- a/kaff4-core/kaff4-core-model/src/test/kotlin/net/navatwo/kaff4/model/rdf/NoneCompressionMethodTest.kt
+++ b/kaff4-core/kaff4-core-model/src/test/kotlin/net/navatwo/kaff4/model/rdf/NoneCompressionMethodTest.kt
@@ -1,12 +1,14 @@
 package net.navatwo.kaff4.model.rdf
 
 import net.navatwo.kaff4.io.repeatByteString
+import net.navatwo.kaff4.model.rdf.CompressionMethod.Companion.NOT_COMPRESSED_SENTINEL_VALUE
+import net.navatwo.kaff4.model.rdf.CompressionMethod.Companion.NOT_UNCOMPRESSED_SENTINEL_VALUE
 import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 
-class NoneCompressionMethodTest {
+internal class NoneCompressionMethodTest {
 
   @Test
   fun compress() {
@@ -20,7 +22,8 @@ class NoneCompressionMethodTest {
 
     compressedBuffer.position(5)
 
-    assertThat(CompressionMethod.None.compress(uncompressedBuffer, compressedBuffer)).isEqualTo(10)
+    assertThat(CompressionMethod.None.compress(uncompressedBuffer, compressedBuffer))
+      .isEqualTo(NOT_COMPRESSED_SENTINEL_VALUE)
 
     assertThat(uncompressedBuffer.position()).isEqualTo(0)
     assertThat(uncompressedBuffer.remaining()).isEqualTo(10)
@@ -30,7 +33,7 @@ class NoneCompressionMethodTest {
     assertThat(compressedBuffer.remaining()).isEqualTo(15)
     assertThat(compressedBuffer.limit()).isEqualTo(20)
 
-    assertThat(compressedBuffer.slice(5, 10).toByteString()).isEqualTo(uncompressedBuffer.toByteString())
+    assertThat(compressedBuffer.toByteString()).isEqualTo(0.repeatByteString(15))
   }
 
   @Test
@@ -45,7 +48,8 @@ class NoneCompressionMethodTest {
 
     uncompressedBuffer.position(5)
 
-    assertThat(CompressionMethod.None.uncompress(compressedBuffer, uncompressedBuffer)).isEqualTo(10)
+    assertThat(CompressionMethod.None.uncompress(compressedBuffer, uncompressedBuffer))
+      .isEqualTo(NOT_UNCOMPRESSED_SENTINEL_VALUE)
 
     assertThat(compressedBuffer.position()).isEqualTo(0)
     assertThat(compressedBuffer.remaining()).isEqualTo(10)
@@ -55,6 +59,6 @@ class NoneCompressionMethodTest {
     assertThat(uncompressedBuffer.remaining()).isEqualTo(15)
     assertThat(uncompressedBuffer.limit()).isEqualTo(20)
 
-    assertThat(uncompressedBuffer.slice(5, 10).toByteString()).isEqualTo(compressedBuffer.toByteString())
+    assertThat(uncompressedBuffer.slice(5, 10).toByteString()).isEqualTo(0.repeatByteString(10))
   }
 }

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/io/ByteStringExtensions.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/io/ByteStringExtensions.kt
@@ -1,7 +1,11 @@
 package net.navatwo.kaff4.io
 
+import net.navatwo.kaff4.satisfies
 import okio.ByteString
+import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.toByteString
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.Assertions.assertThat
 
 fun Byte.repeatByteString(length: Int): ByteString {
   val bytes = ByteArray(length) { this }
@@ -12,4 +16,11 @@ fun Int.repeatByteString(length: Int): ByteString {
   check(this.toUByte() in UByte.MIN_VALUE..UByte.MAX_VALUE)
 
   return toByte().repeatByteString(length)
+}
+
+fun <SELF : AbstractAssert<out SELF, ByteString>> SELF.md5(md5: String): SELF {
+  return `as` { "md5($md5)" }
+    .satisfies { byteString ->
+      assertThat(byteString.md5()).isEqualTo(md5.decodeHex())
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "kaff4"
 
 include(
   "kaff4-compression:kaff4-compression-snappy",
+  "kaff4-compression:kaff4-compression-test",
   "kaff4-core",
   "kaff4-core:kaff4-core-kotlin",
   "kaff4-core:kaff4-core-model",


### PR DESCRIPTION
This sures up the docs and implementation details for `CompressionMethod` implementations. These were previously implicit but are now tested. The new `BaseCompressionMethodTest` can be extended by future methods (e.g. deflate, lz4) to make sure they are working as expected.