### PR TITLE
[Reader] Add dump stream command

### DIFF
--- a/kaff4-core/kaff4-core-model/kaff4-core-model-api/src/main/kotlin/net/navatwo/kaff4/model/rdf/TurtleIri.kt
+++ b/kaff4-core/kaff4-core-model/kaff4-core-model-api/src/main/kotlin/net/navatwo/kaff4/model/rdf/TurtleIri.kt
@@ -4,7 +4,7 @@ package net.navatwo.kaff4.model.rdf
 value class TurtleIri private constructor(val iri: String) {
   init {
     val index = iri.indexOf(':', startIndex = 1)
-    check(index in (0 until iri.lastIndex)) {
+    require(index in (0 until iri.lastIndex)) {
       "Must use valid IRI syntax for Turtle: \$NAMESPACE:\$LOCAL_NAME (e.g. aff4:Image)"
     }
   }

--- a/kaff4-reader/build.gradle.kts
+++ b/kaff4-reader/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   implementation(Dependencies.LOG4J_API)
   implementation(Dependencies.OKIO)
   implementation(Dependencies.RDF4J_MODEL_API)
+  implementation(Dependencies.RDF4J_MODEL)
   implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
 
   implementation(project(":kaff4-core"))

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/Main.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/Main.kt
@@ -2,14 +2,17 @@ package net.navatwo.kaff4
 
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
+import net.navatwo.kaff4.dump_image.DumpImageStreamSubcommand
 import net.navatwo.kaff4.verify.VerifySubcommand
 
 @OptIn(ExperimentalCli::class)
 fun main(args: Array<String>) {
   val parser = ArgParser("kaff4-cli", strictSubcommandOptionsOrder = true)
 
-  val verify = VerifySubcommand()
-  parser.subcommands(verify)
+  parser.subcommands(
+    VerifySubcommand(),
+    DumpImageStreamSubcommand(),
+  )
 
   parser.parse(args)
 }

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/ReaderModule.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/ReaderModule.kt
@@ -1,0 +1,23 @@
+package net.navatwo.kaff4
+
+import com.google.inject.Module
+import com.google.inject.util.Modules
+import net.navatwo.kaff4.container.Aff4ImageOpenerModule
+import net.navatwo.kaff4.model.rdf.Aff4RdfModelPlugin
+import net.navatwo.kaff4.rdf.MemoryRdfRepositoryPlugin
+import net.navatwo.kaff4.streams.compression.Aff4SnappyPlugin
+import net.navatwo.kaff4.streams.compression.deflate.Aff4DeflatePlugin
+import net.navatwo.kaff4.streams.compression.lz4.Aff4Lz4Plugin
+
+internal object ReaderModule : Module by Modules.combine(
+  RandomsModule,
+  MemoryRdfRepositoryPlugin,
+  Aff4ImageOpenerModule,
+  Aff4CoreModule,
+  Aff4BaseStreamModule,
+  Aff4LogicalModule,
+  Aff4RdfModelPlugin,
+  Aff4SnappyPlugin,
+  Aff4Lz4Plugin,
+  Aff4DeflatePlugin,
+)

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/cli/Aff4ArnArgType.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/cli/Aff4ArnArgType.kt
@@ -1,0 +1,26 @@
+package net.navatwo.kaff4.cli
+
+import kotlinx.cli.ArgType
+import kotlinx.cli.ParsingException
+import net.navatwo.kaff4.model.rdf.Aff4Arn
+import net.navatwo.kaff4.model.rdf.createArn
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory
+
+internal object Aff4ArnArgType : ArgType<Aff4Arn>(hasParameter = true) {
+  private val valueFactory = SimpleValueFactory.getInstance()
+
+  override val description: kotlin.String
+    get() = "{ Unique AFF4 identifier within a container in turtle form. }"
+
+  override fun convert(value: kotlin.String, name: kotlin.String): Aff4Arn {
+    return try {
+      valueFactory.createArn(value)
+    } catch (iae: IllegalArgumentException) {
+      throw ParsingException("Option $name is expected to be IRI: $value").apply {
+        addSuppressed(iae)
+      }
+    }
+  }
+
+  val Companion.Aff4Arn: Aff4ArnArgType get() = Aff4ArnArgType
+}

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/cli/PathArgType.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/cli/PathArgType.kt
@@ -1,0 +1,32 @@
+package net.navatwo.kaff4.cli
+
+import kotlinx.cli.ArgType
+import kotlinx.cli.ParsingException
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Paths
+import kotlin.io.path.exists
+
+internal class PathArgType private constructor(private val requireExistingPath: kotlin.Boolean) :
+  ArgType<Path>(hasParameter = true) {
+  override val description: kotlin.String
+    get() = "{ Value is a path to a file }"
+
+  override fun convert(value: kotlin.String, name: kotlin.String): okio.Path {
+    val path = Paths.get(value)
+
+    if (requireExistingPath && !path.exists()) {
+      throw ParsingException("Option $name is expected to be an existing path: $value")
+    }
+
+    return path.toOkioPath()
+  }
+
+  companion object {
+    val ArgType.Companion.InputPath: PathArgType
+      get() = PathArgType(requireExistingPath = true)
+
+    val ArgType.Companion.OutputPath: PathArgType
+      get() = PathArgType(requireExistingPath = false)
+  }
+}

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/cli/PathArgType.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/cli/PathArgType.kt
@@ -12,7 +12,7 @@ internal class PathArgType private constructor(private val requireExistingPath: 
   override val description: kotlin.String
     get() = "{ Value is a path to a file }"
 
-  override fun convert(value: kotlin.String, name: kotlin.String): okio.Path {
+  override fun convert(value: kotlin.String, name: kotlin.String): Path {
     val path = Paths.get(value)
 
     if (requireExistingPath && !path.exists()) {

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/dump_image/DumpImageAction.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/dump_image/DumpImageAction.kt
@@ -1,0 +1,133 @@
+package net.navatwo.kaff4.dump_image
+
+import com.google.common.base.Stopwatch
+import net.navatwo.kaff4.io.ProgressSink
+import net.navatwo.kaff4.io.TeeSink
+import net.navatwo.kaff4.io.buffer
+import net.navatwo.kaff4.model.Aff4ImageOpener
+import net.navatwo.kaff4.model.Aff4StreamSourceProvider
+import net.navatwo.kaff4.model.rdf.Aff4Arn
+import net.navatwo.logging.Logging
+import okio.BufferedSource
+import okio.FileSystem
+import okio.GzipSink
+import okio.Path
+import okio.Sink
+import okio.Timeout
+import okio.sink
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val logger = Logging.getLogger()
+
+@Singleton
+internal class DumpImageAction @Inject constructor(
+  private val imageOpener: Aff4ImageOpener,
+) {
+  enum class OutputFormat {
+    BIN,
+    GZIP,
+    ;
+  }
+
+  fun execute(
+    imagePath: Path,
+    streamIdentifier: Aff4Arn,
+    outputFormat: OutputFormat,
+    dumpStandardOut: Boolean,
+    outputFile: Path?,
+  ) {
+    openOutputSinks(outputFormat, dumpStandardOut, outputFile).use { outputSink ->
+      imageOpener.open(FileSystem.SYSTEM, imagePath) { container ->
+        logger.debug("Opened image, querying streams")
+
+        val streamOpener = container.streamOpener
+        streamOpener.openStream(streamIdentifier).use { sourceProvider ->
+          val sourceSize = (sourceProvider as? Aff4StreamSourceProvider)?.size?.toBigDecimal()
+
+          // TODO Make this do the things we need, compute md5/sha1, dump to `outputSink`, wrap for `outputFormat` etc
+          sourceProvider.buffer().source(timeout = Timeout.NONE).use { streamSource ->
+            dumpSourceWithProgressReporting(streamSource, outputSink, sourceSize)
+          }
+        }
+      }
+    }
+  }
+
+  private fun dumpSourceWithProgressReporting(streamSource: BufferedSource, outputSink: Sink, sourceSize: BigDecimal?) {
+    ProgressSink(outputSink).use { progressSink ->
+      if (sourceSize != null) {
+        progressSink.addListener(StreamingProgressListener(sourceSize))
+      }
+
+      streamSource.readAll(progressSink)
+
+      if (sourceSize != null) {
+        println("[100%] $sourceSize / $sourceSize bytes")
+      }
+    }
+  }
+
+  private fun openOutputSinks(outputFormat: OutputFormat, dumpStandardOut: Boolean, outputFile: Path?): Sink {
+    val outputSinks = listOfNotNull(
+      System.out.sink().takeIf { dumpStandardOut },
+      outputFile?.let { FileSystem.SYSTEM.sink(it, mustCreate = false) },
+    )
+
+    val outputSink = when {
+      outputSinks.isEmpty() -> error("Must provide at least one output location")
+      outputSinks.size == 1 -> outputSinks.single()
+      else -> TeeSink(outputSinks, timeout = Timeout.NONE, closeAllOnClose = true)
+    }
+
+    return when (outputFormat) {
+      OutputFormat.BIN -> outputSink
+      OutputFormat.GZIP -> GzipSink(outputSink)
+    }
+  }
+
+  private class StreamingProgressListener(sourceSize: BigDecimal) : ProgressSink.Listener {
+    private val sourceSize = sourceSize.setScale(@Suppress("MagicNumber") 4)
+
+    private var dumpedBytes: BigInteger = BigInteger.ZERO
+
+    private var firstReported = false
+
+    private val operationStopwatch: Stopwatch = Stopwatch.createStarted()
+    private val reportStopwatch: Stopwatch = Stopwatch.createStarted()
+
+    override fun onWrite(bytesWritten: Long) {
+      dumpedBytes += bytesWritten.toBigInteger()
+
+      if (!firstReported || reportStopwatch.elapsed() >= REPORT_CADENCE) {
+        val progress = (dumpedBytes.toBigDecimal() / sourceSize * DECIMAL_PERCENT_TO_ONE_HUNDRED_FACTOR)
+          .setScale(2)
+
+        val millisElapsed = operationStopwatch.elapsed(TimeUnit.MILLISECONDS).toBigDecimal()
+        val mibpsRate = if (millisElapsed > BigDecimal.ZERO) {
+          dumpedBytes.toBigDecimal() / millisElapsed * BYTES_PER_MILLI_TO_MIBYTES_PER_SECOND_FACTOR
+        } else {
+          BigDecimal.ZERO
+        }.setScale(2)
+
+        println("[$progress%] $dumpedBytes / $sourceSize bytes ($mibpsRate MiB/second)")
+
+        reportStopwatch.reset()
+        reportStopwatch.start()
+
+        firstReported = true
+      }
+    }
+  }
+
+  companion object {
+    private val REPORT_CADENCE = Duration.ofMillis(250)
+    private val DECIMAL_PERCENT_TO_ONE_HUNDRED_FACTOR = 100.toBigDecimal()
+    private val BYTES_PER_MILLI_TO_MIBYTES_PER_SECOND_FACTOR =
+      1000.toBigDecimal().setScale(4) / (1024 * 1024).toBigDecimal()
+  }
+}

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/dump_image/DumpImageStreamSubcommand.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/dump_image/DumpImageStreamSubcommand.kt
@@ -1,0 +1,59 @@
+package net.navatwo.kaff4.dump_image
+
+import com.google.inject.Guice
+import kotlinx.cli.ArgType
+import kotlinx.cli.ExperimentalCli
+import kotlinx.cli.Subcommand
+import kotlinx.cli.default
+import net.navatwo.guice.getInstance
+import net.navatwo.kaff4.ReaderModule
+import net.navatwo.kaff4.cli.Aff4ArnArgType.Aff4Arn
+import net.navatwo.kaff4.cli.PathArgType.Companion.InputPath
+import net.navatwo.kaff4.cli.PathArgType.Companion.OutputPath
+import net.navatwo.kaff4.dump_image.DumpImageAction.OutputFormat
+
+@ExperimentalCli
+internal class DumpImageStreamSubcommand : Subcommand("dump-stream", "Dump an image stream") {
+  private val inputPath by argument(
+    type = ArgType.InputPath,
+    fullName = "input_container",
+    description = "Input container to read"
+  )
+
+  private val streamIdentifier by argument(
+    type = ArgType.Aff4Arn,
+    fullName = "stream-name",
+    description = "Stream within {input_container} to dump",
+  )
+
+  private val dumpStandardOut by option(
+    type = ArgType.Boolean,
+    fullName = "stdout",
+    description = "Dump the output to the standard output, useful for piping to other applications",
+  ).default(false)
+
+  private val outputFile by option(
+    type = ArgType.OutputPath,
+    fullName = "output_file",
+    description = "Output file to dump to",
+  )
+
+  private val outputFormat by option(
+    type = ArgType.Choice<OutputFormat>(),
+    fullName = "format",
+    description = "Output format to use",
+  ).default(OutputFormat.BIN)
+
+  override fun execute() {
+    val injector = Guice.createInjector(ReaderModule)
+
+    val verifyAction = injector.getInstance<DumpImageAction>()
+    verifyAction.execute(
+      imagePath = inputPath,
+      streamIdentifier = streamIdentifier,
+      outputFormat = outputFormat,
+      dumpStandardOut = dumpStandardOut,
+      outputFile = outputFile
+    )
+  }
+}

--- a/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/io/ProgressSink.kt
+++ b/kaff4-reader/src/main/kotlin/net/navatwo/kaff4/io/ProgressSink.kt
@@ -1,0 +1,26 @@
+package net.navatwo.kaff4.io
+
+import okio.Buffer
+import okio.Sink
+
+internal data class ProgressSink(
+  private val sink: Sink,
+) : Sink by sink {
+  private val listeners = mutableListOf<Listener>()
+
+  fun addListener(listener: Listener) {
+    listeners += listener
+  }
+
+  override fun write(source: Buffer, byteCount: Long) {
+    sink.write(source, byteCount)
+
+    for (reporter in listeners) {
+      reporter.onWrite(byteCount)
+    }
+  }
+
+  interface Listener {
+    fun onWrite(bytesWritten: Long)
+  }
+}


### PR DESCRIPTION
This dumps an AFF4 stream to a file with or without compression.

Sample:

```shell
reader dump-stream \
    "./test_images/base-linear_striped/Base-Linear_1.aff4" \
    "aff4://2dd04819-73c8-40e3-a32b-fdddb0317eac" \
    --format GZIP \
    --output_file "./stream.bin.gz"
```

Thus dumps the output to a GZIP'd RAW of the stream `aff4://2dd04819-73c8-40e3-a32b-fdddb0317eac` which is the entire image.