### PR TITLE
[Dependencies] Port from `javax.inject` -> `jakarta.inject`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ guava = "com.google.guava:guava:32.0.1-jre"
 guice = { module = "com.google.inject:guice", version.ref = "guice" }
 guice-assistedInject = { module = "com.google.inject.extensions:guice-assistedinject", version.ref = "guice" }
 
-javax-inject = "javax.inject:javax.inject:1"
+jakarta-inject-api = "jakarta.inject:jakarta.inject-api:2.0.1"
 
 kintervaltree = "net.navatwo:kinterval-tree:0.1.0"
 

--- a/kaff4-cli/build.gradle.kts
+++ b/kaff4-cli/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(libs.guice)
-  implementation(libs.javax.inject)
+  implementation(libs.jakarta.inject.api)
   implementation(libs.misk.actionscopes)
   implementation(libs.log4j.api)
   implementation(libs.okio)

--- a/kaff4-cli/src/main/kotlin/net/navatwo/kaff4/dump_image/DumpImageAction.kt
+++ b/kaff4-cli/src/main/kotlin/net/navatwo/kaff4/dump_image/DumpImageAction.kt
@@ -1,6 +1,8 @@
 package net.navatwo.kaff4.dump_image
 
 import com.google.common.base.Stopwatch
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.io.ProgressSink
 import net.navatwo.kaff4.io.TeeSink
 import net.navatwo.kaff4.io.buffer
@@ -19,8 +21,6 @@ import java.math.BigInteger
 import java.math.RoundingMode
 import java.time.Duration
 import java.util.concurrent.TimeUnit
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class DumpImageAction @Inject constructor(

--- a/kaff4-cli/src/main/kotlin/net/navatwo/kaff4/verify/VerifyAction.kt
+++ b/kaff4-cli/src/main/kotlin/net/navatwo/kaff4/verify/VerifyAction.kt
@@ -1,5 +1,8 @@
 package net.navatwo.kaff4.verify
 
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import jakarta.inject.Singleton
 import misk.scope.ActionScope
 import misk.scope.executor.ActionScopedExecutorService
 import net.navatwo.kaff4.model.Aff4Image
@@ -18,9 +21,6 @@ import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 
 private val logger = Logging.getLogger()
 

--- a/kaff4-compression/build.gradle.kts
+++ b/kaff4-compression/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
   implementation(kotlin("stdlib-jdk8"))
 
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
 
   api(project(":kaff4-plugin"))
   api(project(":kaff4-core:kaff4-core-model:kaff4-core-model-api"))

--- a/kaff4-compression/kaff4-compression-lz4/build.gradle.kts
+++ b/kaff4-compression/kaff4-compression-lz4/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
   implementation(kotlin("stdlib-jdk8"))
 
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
 
   api(project(":kaff4-plugin"))
   api(project(":kaff4-core:kaff4-core-model:kaff4-core-model-api"))

--- a/kaff4-compression/kaff4-compression-lz4/src/main/kotlin/net/navatwo/kaff4/streams/compression/lz4/Lz4Compression.kt
+++ b/kaff4-compression/kaff4-compression-lz4/src/main/kotlin/net/navatwo/kaff4/streams/compression/lz4/Lz4Compression.kt
@@ -1,6 +1,8 @@
 package net.navatwo.kaff4.streams.compression.lz4
 
 import com.google.common.io.ByteStreams
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.model.rdf.CompressionMethod
 import net.navatwo.kaff4.streams.compression.ByteBuffers.markAndReset
 import net.navatwo.kaff4.streams.compression.Streams.useAsInputStream
@@ -9,8 +11,6 @@ import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStrea
 import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class Lz4Compression @Inject internal constructor() : CompressionMethod {

--- a/kaff4-compression/kaff4-compression-lz4/src/test/kotlin/net/navatwo/kaff4/streams/compression/lz4/Lz4CompressionTest.kt
+++ b/kaff4-compression/kaff4-compression-lz4/src/test/kotlin/net/navatwo/kaff4/streams/compression/lz4/Lz4CompressionTest.kt
@@ -1,10 +1,10 @@
 package net.navatwo.kaff4.streams.compression.lz4
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.streams.compression.BaseCompressionMethodTest
 import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 internal class Lz4CompressionTest : BaseCompressionMethodTest() {
   @GuiceModule

--- a/kaff4-compression/kaff4-compression-snappy/build.gradle.kts
+++ b/kaff4-compression/kaff4-compression-snappy/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
   implementation(kotlin("stdlib-jdk8"))
 
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
 
   api(project(":kaff4-plugin"))
   api(project(":kaff4-core:kaff4-core-model:kaff4-core-model-api"))

--- a/kaff4-compression/kaff4-compression-snappy/src/main/kotlin/net/navatwo/kaff4/streams/compression/SnappyCompression.kt
+++ b/kaff4-compression/kaff4-compression-snappy/src/main/kotlin/net/navatwo/kaff4/streams/compression/SnappyCompression.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4.streams.compression
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.model.rdf.CompressionMethod
 import net.navatwo.kaff4.model.rdf.CompressionMethod.Companion.NOT_UNCOMPRESSED_SENTINEL_VALUE
 import org.xerial.snappy.Snappy
 import java.nio.ByteBuffer
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class SnappyCompression @Inject internal constructor() : CompressionMethod {

--- a/kaff4-compression/kaff4-compression-snappy/src/test/kotlin/net/navatwo/kaff4/streams/compression/SnappyCompressionTest.kt
+++ b/kaff4-compression/kaff4-compression-snappy/src/test/kotlin/net/navatwo/kaff4/streams/compression/SnappyCompressionTest.kt
@@ -1,9 +1,9 @@
 package net.navatwo.kaff4.streams.compression
 
+import jakarta.inject.Inject
 import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class SnappyCompressionTest : BaseCompressionMethodTest() {
   @GuiceModule

--- a/kaff4-compression/src/main/kotlin/net/navatwo/kaff4/streams/compression/deflate/DeflateCompression.kt
+++ b/kaff4-compression/src/main/kotlin/net/navatwo/kaff4/streams/compression/deflate/DeflateCompression.kt
@@ -1,12 +1,12 @@
 package net.navatwo.kaff4.streams.compression.deflate
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.model.rdf.CompressionMethod
 import net.navatwo.kaff4.streams.compression.ByteBuffers.markAndReset
 import java.nio.ByteBuffer
 import java.util.zip.Deflater
 import java.util.zip.Inflater
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class DeflateCompression @Inject internal constructor() : CompressionMethod {

--- a/kaff4-compression/src/test/kotlin/net/navatwo/kaff4/streams/compression/deflate/DeflateCompressionTest.kt
+++ b/kaff4-compression/src/test/kotlin/net/navatwo/kaff4/streams/compression/deflate/DeflateCompressionTest.kt
@@ -1,10 +1,10 @@
 package net.navatwo.kaff4.streams.compression.deflate
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.streams.compression.BaseCompressionMethodTest
 import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 internal class DeflateCompressionTest : BaseCompressionMethodTest() {
   @GuiceModule

--- a/kaff4-core/build.gradle.kts
+++ b/kaff4-core/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
   implementation(kotlin("reflect"))
 
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.okio)
   api(libs.rdf4j.model.api)
   api(libs.kintervaltree)

--- a/kaff4-core/kaff4-core-guice/build.gradle.kts
+++ b/kaff4-core/kaff4-core-guice/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
   runtimeOnly(kotlin("reflect"))
 
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.misk.inject)
 
   implementation(libs.guice.assistedInject)

--- a/kaff4-core/kaff4-core-guice/src/main/kotlin/net/navatwo/guice/GuiceExtensions.kt
+++ b/kaff4-core/kaff4-core-guice/src/main/kotlin/net/navatwo/guice/GuiceExtensions.kt
@@ -6,7 +6,7 @@ import com.google.inject.TypeLiteral
 import com.google.inject.binder.AnnotatedBindingBuilder
 import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
-import javax.inject.Provider
+import jakarta.inject.Provider
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 

--- a/kaff4-core/kaff4-core-guice/src/main/kotlin/net/navatwo/guice/KSetMultibinderHelper.kt
+++ b/kaff4-core/kaff4-core-guice/src/main/kotlin/net/navatwo/guice/KSetMultibinderHelper.kt
@@ -2,14 +2,9 @@ package net.navatwo.guice
 
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.multibindings.Multibinder
-import javax.inject.Provider
 
 class KSetMultibinderHelper<T>(val multibinder: Multibinder<T>) {
   inline fun <reified U : T> to(): ScopedBindingBuilder = multibinder.addBinding().to(typeLiteral<U>())
-
-  fun <U : T> toProvider(provider: Provider<out U>) = multibinder.addBinding().toProvider(provider)
-
-  fun <U : T> toProvider(provider: com.google.inject.Provider<out U>) = multibinder.addBinding().toProvider(provider)
 
   fun <U : T> toInstance(instance: U) = multibinder.addBinding().toInstance(instance)
 }

--- a/kaff4-core/kaff4-core-model/build.gradle.kts
+++ b/kaff4-core/kaff4-core-model/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   api(project(":kaff4-rdf"))
 
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.okio)
   api(libs.rdf4j.model.api)
 

--- a/kaff4-core/kaff4-core-model/kaff4-core-model-api/build.gradle.kts
+++ b/kaff4-core/kaff4-core-model/kaff4-core-model-api/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
   api(libs.guava)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.okio)
   api(libs.rdf4j.model.api)
   api(libs.rdf4j.query)

--- a/kaff4-core/kaff4-core-model/kaff4-core-model-api/src/main/kotlin/net/navatwo/kaff4/model/dialect/DefaultToolDialect.kt
+++ b/kaff4-core/kaff4-core-model/kaff4-core-model-api/src/main/kotlin/net/navatwo/kaff4/model/dialect/DefaultToolDialect.kt
@@ -1,6 +1,6 @@
 package net.navatwo.kaff4.model.dialect
 
-import javax.inject.Qualifier
+import jakarta.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.FIELD
 import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER

--- a/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/dialect/Aff4LogicalStandardToolDialect.kt
+++ b/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/dialect/Aff4LogicalStandardToolDialect.kt
@@ -1,10 +1,10 @@
 package net.navatwo.kaff4.model.dialect
 
 import com.google.inject.Provides
+import jakarta.inject.Singleton
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.kaff4.model.Aff4Container
 import net.navatwo.kaff4.model.rdf.Aff4RdfModel
-import javax.inject.Singleton
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass

--- a/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/Aff4CompressionMethodValueConverter.kt
+++ b/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/Aff4CompressionMethodValueConverter.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4.model.rdf
 
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import org.eclipse.rdf4j.model.Value
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 
 @Singleton
 internal class Aff4CompressionMethodValueConverter @Inject constructor(

--- a/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/Aff4HashRdfValueConverter.kt
+++ b/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/Aff4HashRdfValueConverter.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4.model.rdf
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.Value
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class Aff4HashRdfValueConverter @Inject constructor() : ConcreteRdfValueConverter<Hash>(typeLiteral<Hash>()) {

--- a/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/Aff4ImagePathRdfValueConverter.kt
+++ b/kaff4-core/kaff4-core-model/src/main/kotlin/net/navatwo/kaff4/model/rdf/Aff4ImagePathRdfValueConverter.kt
@@ -1,13 +1,13 @@
 package net.navatwo.kaff4.model.rdf
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import okio.Path
 import okio.Path.Companion.toPath
 import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.Value
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class Aff4ImagePathRdfValueConverter @Inject constructor() :

--- a/kaff4-core/kaff4-core-model/src/test/kotlin/net/navatwo/kaff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
+++ b/kaff4-core/kaff4-core-model/src/test/kotlin/net/navatwo/kaff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
@@ -1,6 +1,8 @@
 package net.navatwo.kaff4.model.dialect
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
+import jakarta.inject.Provider
 import net.navatwo.kaff4.Aff4TestModule
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.TestToolDialectModule
@@ -13,8 +15,6 @@ import net.navatwo.kaff4.model.rdf.ZipSegment
 import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
-import javax.inject.Provider
 
 internal class Aff4LogicalStandardToolDialectTest {
   @GuiceModule

--- a/kaff4-core/kaff4-core-test/build.gradle.kts
+++ b/kaff4-core/kaff4-core-test/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
   api(libs.assertj)
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.junit.juipter.api)
   api(libs.okio)
 

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/Aff4ImageTestModule.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/Aff4ImageTestModule.kt
@@ -1,6 +1,8 @@
 package net.navatwo.kaff4
 
 import com.google.inject.Provides
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.kaff4.container.Aff4ImageOpenerModule
 import net.navatwo.kaff4.model.Aff4Image
@@ -8,8 +10,6 @@ import net.navatwo.kaff4.model.Aff4ImageOpener
 import net.navatwo.test.GuiceExtension
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import javax.inject.Inject
-import javax.inject.Singleton
 
 abstract class Aff4ImageTestModule(val imageName: String) : KAff4AbstractModule() {
   val imagePath = imageName.toPath()

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/Aff4TestModule.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/Aff4TestModule.kt
@@ -1,13 +1,13 @@
 package net.navatwo.kaff4
 
 import com.google.inject.Provides
+import jakarta.inject.Singleton
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.kaff4.io.relativeTo
 import net.navatwo.kaff4.model.rdf.Aff4RdfModelPlugin
 import net.navatwo.kaff4.rdf.MemoryRdfRepositoryPlugin
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import javax.inject.Singleton
 
 object Aff4TestModule : KAff4AbstractModule() {
   override fun configure() {

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/ForImages.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/ForImages.kt
@@ -1,6 +1,6 @@
 package net.navatwo.kaff4
 
-import javax.inject.Qualifier
+import jakarta.inject.Qualifier
 
 @Target(
   AnnotationTarget.PROPERTY,

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/ForResources.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/ForResources.kt
@@ -1,6 +1,6 @@
 package net.navatwo.kaff4
 
-import javax.inject.Qualifier
+import jakarta.inject.Qualifier
 
 @Target(
   AnnotationTarget.PROPERTY,

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/TestActionScopeModule.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/TestActionScopeModule.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4
 
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import jakarta.inject.Singleton
 import misk.scope.ActionScope
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.test.GuiceExtension
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 
 object TestActionScopeModule : KAff4AbstractModule() {
   override fun configure() {

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/TestRandomsModule.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/TestRandomsModule.kt
@@ -4,13 +4,12 @@ import com.google.inject.Module
 import com.google.inject.util.Modules
 import net.navatwo.guice.KAff4AbstractModule
 import java.util.Random
-import javax.inject.Provider
 
 object TestRandomsModule : Module by Modules.override(RandomsModule)
   .with(
     object : KAff4AbstractModule() {
       override fun configure() {
-        bind<Random>().toProvider(Provider { Random(0) })
+        bind<Random>().toProvider { Random(0) }
       }
     }
   )

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/TestToolDialectModule.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/TestToolDialectModule.kt
@@ -1,5 +1,7 @@
 package net.navatwo.kaff4
 
+import jakarta.inject.Inject
+import jakarta.inject.Provider
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
 import net.navatwo.guice.KAff4AbstractModule
@@ -7,8 +9,6 @@ import net.navatwo.kaff4.model.dialect.Aff4LogicalStandardToolDialect
 import net.navatwo.kaff4.model.dialect.DialectsModule
 import net.navatwo.kaff4.model.dialect.ToolDialect
 import net.navatwo.kaff4.model.rdf.Aff4RdfModelPlugin
-import javax.inject.Inject
-import javax.inject.Provider
 
 object TestToolDialectModule : KAff4AbstractModule() {
   override fun configure() {

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/UnderTest.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/UnderTest.kt
@@ -1,6 +1,6 @@
 package net.navatwo.kaff4
 
-import javax.inject.Qualifier
+import jakarta.inject.Qualifier
 
 /**
  * Defines a value that is provided from a test rule.

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/test/GuiceExtension.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/test/GuiceExtension.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace
 import java.lang.reflect.ParameterizedType
-import javax.inject.Provider
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
@@ -117,7 +116,7 @@ class GuiceExtension : BeforeEachCallback, AfterEachCallback, BeforeAllCallback 
 
   private object TestModule : KAff4AbstractModule() {
     override fun configure() {
-      bind<Sha256FileSystemFactory>().toProvider(Provider { Sha256FileSystemFactory() })
+      bind<Sha256FileSystemFactory>().toProvider { Sha256FileSystemFactory() }
 
       bindSet<TestLifecycleAction> {
         to<OffTestThreadExecutor>()

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/test/OffTestThreadExecutor.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/test/OffTestThreadExecutor.kt
@@ -1,9 +1,9 @@
 package net.navatwo.test
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Runs code in a separate thread. This is typically used to avoid collisions between action scopes in tests.

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/Aff4ImageOpenerModule.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/Aff4ImageOpenerModule.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.container
 
+import jakarta.inject.Inject
 import misk.scope.ActionScoped
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
@@ -13,7 +14,6 @@ import net.navatwo.kaff4.model.Aff4StreamOpener
 import net.navatwo.kaff4.model.Aff4StreamOpenerModule
 import net.navatwo.kaff4.model.dialect.ToolDialect
 import net.navatwo.kaff4.rdf.RdfExecutor
-import javax.inject.Inject
 
 object Aff4ImageOpenerModule : KAff4AbstractModule() {
   override fun configure() {

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ContainerDataFileSystemProvider.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ContainerDataFileSystemProvider.kt
@@ -1,12 +1,12 @@
 package net.navatwo.kaff4.container
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.scope.ActionScoped
 import net.navatwo.kaff4.model.Aff4ImageContext
 import net.navatwo.kaff4.model.rdf.Aff4Arn
 import net.navatwo.kaff4.model.rdf.StoredRdfModel
 import okio.FileSystem
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class ContainerDataFileSystemProvider @Inject constructor(

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ContainerLoader.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ContainerLoader.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.container
 
 import com.google.common.annotations.VisibleForTesting
+import jakarta.inject.Inject
 import net.navatwo.kaff4.container.RealAff4ImageOpener.LoadedContainersContext
 import net.navatwo.kaff4.io.relativeTo
 import net.navatwo.kaff4.model.Aff4Container
@@ -10,7 +11,6 @@ import okio.Path
 import okio.Path.Companion.toPath
 import okio.openZip
 import org.eclipse.rdf4j.model.ValueFactory
-import javax.inject.Inject
 import kotlin.io.path.name
 
 private val AFF4_STRIPE_PATTERNS = listOf(

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ContainerMetaWriter.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ContainerMetaWriter.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.container
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.model.rdf.Aff4Arn
 import net.navatwo.kaff4.rdf.QueryableRdfConnection
 import okio.FileSystem
@@ -7,7 +8,6 @@ import okio.Path.Companion.toPath
 import org.eclipse.rdf4j.rio.RDFFormat
 import org.eclipse.rdf4j.rio.RDFWriter
 import org.eclipse.rdf4j.rio.Rio
-import javax.inject.Inject
 
 internal class ContainerMetaWriter @Inject constructor() {
   fun write(connection: QueryableRdfConnection, fileSystem: FileSystem, containerArn: Aff4Arn) {

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/RealAff4ImageOpener.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/RealAff4ImageOpener.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.container
 
+import jakarta.inject.Inject
 import misk.scope.ActionScope
 import misk.scope.ActionScoped
 import net.navatwo.guice.key
@@ -9,7 +10,6 @@ import net.navatwo.kaff4.model.Aff4ImageOpener
 import net.navatwo.kaff4.model.Aff4ImageOpener.Aff4ImageWithResources
 import okio.FileSystem
 import okio.Path
-import javax.inject.Inject
 
 internal class RealAff4ImageOpener @Inject constructor(
   private val actionScope: ActionScope,

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ToolDialectResolver.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/container/ToolDialectResolver.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4.container
 
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.model.Aff4Container
 import net.navatwo.kaff4.model.dialect.DefaultToolDialect
 import net.navatwo.kaff4.model.dialect.ToolDialect
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 
 @Singleton
 internal class ToolDialectResolver @Inject constructor(

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/model/RealAff4Model.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/model/RealAff4Model.kt
@@ -2,6 +2,8 @@ package net.navatwo.kaff4.model
 
 import com.google.inject.assistedinject.Assisted
 import com.google.inject.assistedinject.AssistedInject
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.scope.ActionScoped
 import net.navatwo.kaff4.model.dialect.ToolDialect
 import net.navatwo.kaff4.model.rdf.Aff4RdfModel
@@ -17,8 +19,6 @@ import org.eclipse.rdf4j.model.Resource
 import org.eclipse.rdf4j.model.Statement
 import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.query.GraphQuery
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 private val PATTERN_ORDER_BY = Regex("\\s+order by\\s+", RegexOption.IGNORE_CASE)

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/model/RealAff4StreamOpener.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/model/RealAff4StreamOpener.kt
@@ -3,6 +3,7 @@ package net.navatwo.kaff4.model
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
 import com.google.inject.TypeLiteral
+import jakarta.inject.Inject
 import misk.scope.ActionScoped
 import net.navatwo.kaff4.io.AutoCloseableSourceProvider
 import net.navatwo.kaff4.io.SourceProvider
@@ -28,7 +29,6 @@ import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Proxy
-import javax.inject.Inject
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.javaType

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/model/dialect/Pyaff4Version11ToolDialect.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/model/dialect/Pyaff4Version11ToolDialect.kt
@@ -1,10 +1,10 @@
 package net.navatwo.kaff4.model.dialect
 
 import com.google.inject.Provides
+import jakarta.inject.Singleton
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.kaff4.model.Aff4Container
 import net.navatwo.kaff4.model.rdf.ZipSegment
-import javax.inject.Singleton
 
 class Pyaff4Version11ToolDialect private constructor(override val typeResolver: DialectTypeResolver) : ToolDialect {
   override fun isApplicable(toolMetadata: Aff4Container.ToolMetadata): Boolean {

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/Aff4StreamLoaderContext.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/Aff4StreamLoaderContext.kt
@@ -1,9 +1,9 @@
 package net.navatwo.kaff4.streams
 
 import com.google.inject.TypeLiteral
+import jakarta.inject.Provider
 import net.navatwo.kaff4.model.Aff4StreamSourceProvider
 import net.navatwo.kaff4.model.rdf.Aff4RdfModel
-import javax.inject.Provider
 
 internal class Aff4StreamLoaderContext(
   val configTypeLiteral: TypeLiteral<out Aff4RdfModel>,

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4BevySink.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4BevySink.kt
@@ -1,5 +1,7 @@
 package net.navatwo.kaff4.streams.image_stream
 
+import jakarta.inject.Inject
+import jakarta.inject.Named
 import net.navatwo.kaff4.io.source
 import net.navatwo.kaff4.model.rdf.ImageStream
 import net.navatwo.kaff4.streams.computeLinearHashes
@@ -9,8 +11,6 @@ import okio.Sink
 import okio.Timeout
 import okio.buffer
 import java.nio.ByteBuffer
-import javax.inject.Inject
-import javax.inject.Named
 
 internal class Aff4BevySink @Inject constructor(
   @Named("ImageOutput") private val outputFileSystem: FileSystem,

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/Bevy.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/Bevy.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.image_stream
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.container.ContainerDataFileSystemProvider
 import net.navatwo.kaff4.mapNotNullValues
 import net.navatwo.kaff4.model.rdf.Aff4Arn
@@ -9,7 +10,6 @@ import net.navatwo.kaff4.model.rdf.createArn
 import net.navatwo.kaff4.model.rdf.toAff4Path
 import okio.Path
 import org.eclipse.rdf4j.model.ValueFactory
-import javax.inject.Inject
 
 private const val BEVY_FILENAME_PADDING_LENGTH = 8
 

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/BevyIndexCache.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/BevyIndexCache.kt
@@ -1,9 +1,9 @@
 package net.navatwo.kaff4.streams.image_stream
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.model.IRI
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val INDEX_CACHE_SIZE = 500L
 

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/ImageBlockHashVerification.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/image_stream/ImageBlockHashVerification.kt
@@ -1,6 +1,8 @@
 package net.navatwo.kaff4.streams.image_stream
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.container.ContainerDataFileSystemProvider
 import net.navatwo.kaff4.io.source
 import net.navatwo.kaff4.model.rdf.HashType
@@ -9,8 +11,6 @@ import okio.ByteString
 import okio.Timeout
 import org.eclipse.rdf4j.model.IRI
 import java.nio.ByteBuffer
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val BLOCK_HASH_VALUES_CACHE = 1024L
 

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/map_stream/MapIdxFileReader.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/map_stream/MapIdxFileReader.kt
@@ -1,6 +1,8 @@
 package net.navatwo.kaff4.streams.map_stream
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.container.ContainerDataFileSystemProvider
 import net.navatwo.kaff4.io.lineSequence
 import net.navatwo.kaff4.model.rdf.Aff4Arn
@@ -9,8 +11,6 @@ import net.navatwo.kaff4.model.rdf.createArn
 import okio.Path
 import okio.buffer
 import org.eclipse.rdf4j.model.ValueFactory
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val MAP_TARGETS_CACHE_SIZE = 10L
 

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamMapReader.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamMapReader.kt
@@ -1,13 +1,13 @@
 package net.navatwo.kaff4.streams.map_stream
 
 import com.github.nava2.interval_tree.IntervalTree
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.container.ContainerDataFileSystemProvider
 import net.navatwo.kaff4.model.rdf.MapStream
 import net.navatwo.kaff4.streams.symbolics.Symbolics
 import okio.buffer
 import org.eclipse.rdf4j.model.IRI
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val ENTRIES_INSERT_CHUNK_SIZE = 50
 

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/symbolics/Symbolics.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/symbolics/Symbolics.kt
@@ -1,5 +1,7 @@
 package net.navatwo.kaff4.streams.symbolics
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.model.rdf.Aff4Arn
 import net.navatwo.kaff4.model.rdf.Aff4Schema
 import net.navatwo.kaff4.model.rdf.createAff4Iri
@@ -7,8 +9,6 @@ import okio.ByteString
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encode
 import org.eclipse.rdf4j.model.ValueFactory
-import javax.inject.Inject
-import javax.inject.Singleton
 
 // https://github.com/aff4/Standard/blob/master/inprogress/AFF4StandardSpecification-v1.0a.md#44-symbolic-streams
 private const val AFF4_SYMBOLIC_CHUNK_BOUNDARY = 1 * 1024 * 1024

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/container/Aff4ImageOpenerModuleTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/container/Aff4ImageOpenerModuleTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.container
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import misk.scope.ActionScoped
 import net.navatwo.kaff4.Aff4BaseStreamModule
 import net.navatwo.kaff4.Aff4CoreModule
@@ -19,7 +20,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 private const val BASE_LINEAR_NAME = "Base-Linear"
 private const val BASE_LINEAR_IMAGE = "$BASE_LINEAR_NAME.aff4"

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/container/ContainerLoaderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/container/ContainerLoaderTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.container
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.Aff4TestModule
 import net.navatwo.kaff4.BaseLinear
@@ -29,7 +30,6 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
-import javax.inject.Inject
 
 internal class ContainerLoaderTest {
   companion object {

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/container/ToolDialectResolverTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/container/ToolDialectResolverTest.kt
@@ -1,6 +1,9 @@
 package net.navatwo.kaff4.container
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import jakarta.inject.Singleton
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
 import net.navatwo.guice.KAff4AbstractModule
@@ -17,9 +20,6 @@ import net.navatwo.kaff4.model.rdf.Aff4RdfModelPlugin
 import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 
 internal class ToolDialectResolverTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelBaseLinearTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelBaseLinearTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.model
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -29,7 +30,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4ModelBaseLinearTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelDreamTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelDreamTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.model
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.Dream
 import net.navatwo.kaff4.UnderTest
@@ -16,7 +17,6 @@ import okio.Path.Companion.toPath
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4ModelDreamTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelNestedLogicalImagesTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelNestedLogicalImagesTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.model
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.NestedLogicalImages
 import net.navatwo.kaff4.UnderTest
@@ -10,7 +11,6 @@ import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4ModelNestedLogicalImagesTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelStripedBaseLinearTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/model/Aff4ModelStripedBaseLinearTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.model
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinearStriped
 import net.navatwo.kaff4.UnderTest
@@ -27,7 +28,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4ModelStripedBaseLinearTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4BevySinkTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4BevySinkTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.streams.image_stream
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.UsingTemporary
 import net.navatwo.kaff4.io.content
@@ -25,7 +26,6 @@ import okio.buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4BevySinkTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4BevySourceProviderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4BevySourceProviderTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.image_stream
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -14,7 +15,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4BevySourceProviderTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4ImageStreamSinkTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4ImageStreamSinkTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.streams.image_stream
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4BaseStreamModule
 import net.navatwo.kaff4.UsingTemporary
 import net.navatwo.kaff4.container.Aff4ContainerBuilder
@@ -40,7 +41,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import javax.inject.Inject
 
 internal class Aff4ImageStreamSinkTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4ImageStreamSourceProviderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/Aff4ImageStreamSourceProviderTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.image_stream
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -17,7 +18,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class Aff4ImageStreamSourceProviderTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/BevyIndexReaderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/image_stream/BevyIndexReaderTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.image_stream
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -13,7 +14,6 @@ import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class BevyIndexReaderTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/Aff4MapStreamSinkTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/Aff4MapStreamSinkTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.streams.map_stream
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4BaseStreamModule
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.UsingTemporary
@@ -41,7 +42,6 @@ import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.function.Consumer
-import javax.inject.Inject
 
 class Aff4MapStreamSinkTest {
 

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/Aff4MapStreamSourceProviderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/Aff4MapStreamSourceProviderTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.map_stream
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -20,7 +21,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 private const val CHUNK_SIZE: Long = 32 * 1024
 

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapIdxFileReaderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapIdxFileReaderTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.map_stream
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -11,7 +12,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class MapIdxFileReaderTest {
 

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamDataChunkerBufferedSinkTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamDataChunkerBufferedSinkTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.streams.map_stream
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4CoreModule
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.container.Aff4ImageOpenerModule
@@ -14,7 +15,6 @@ import okio.Timeout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class MapStreamDataChunkerBufferedSinkTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamEntryIntervalTreeExtensionsTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamEntryIntervalTreeExtensionsTest.kt
@@ -2,6 +2,7 @@ package net.navatwo.kaff4.streams.map_stream
 
 import com.github.nava2.interval_tree.IntervalTree
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4CoreModule
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.container.Aff4ImageOpenerModule
@@ -10,7 +11,6 @@ import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class MapStreamEntryIntervalTreeExtensionsTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamEntryTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamEntryTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.streams.map_stream
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4CoreModule
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.container.Aff4ImageOpenerModule
@@ -14,7 +15,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class MapStreamEntryTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamMapReaderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/map_stream/MapStreamMapReaderTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.streams.map_stream
 
 import com.github.nava2.interval_tree.Interval
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.UnderTest
@@ -13,7 +14,6 @@ import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.function.Consumer
-import javax.inject.Inject
 
 class MapStreamMapReaderTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/symbolics/SymbolicSourceProviderTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/symbolics/SymbolicSourceProviderTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.symbolics
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.io.buffer
@@ -10,7 +11,6 @@ import net.navatwo.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class SymbolicSourceProviderTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/symbolics/SymbolicsTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/symbolics/SymbolicsTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.symbolics
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.BaseLinear
 import net.navatwo.kaff4.io.limit
@@ -11,7 +12,6 @@ import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 class SymbolicsTest {
   @GuiceModule

--- a/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/zip_segment/Aff4ZipSegmentTest.kt
+++ b/kaff4-core/src/test/kotlin/net/navatwo/kaff4/streams/zip_segment/Aff4ZipSegmentTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.streams.zip_segment
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4ImageTestModule
 import net.navatwo.kaff4.Dream
 import net.navatwo.kaff4.UnderTest
@@ -19,7 +20,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 private const val DREAM_TXT_SIZE = 8688L
 private val DREAM_FIRST_LINE = "I have a Dream by Martin Luther King, Jr; August 28, 1963\n".encodeUtf8()

--- a/kaff4-plugin/build.gradle.kts
+++ b/kaff4-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.misk.inject)
 
   api(project("::kaff4-core:kaff4-core-model:kaff4-core-model-api"))

--- a/kaff4-plugin/src/main/kotlin/net/navatwo/kaff4/plugins/KAff4Plugin.kt
+++ b/kaff4-plugin/src/main/kotlin/net/navatwo/kaff4/plugins/KAff4Plugin.kt
@@ -1,13 +1,13 @@
 package net.navatwo.kaff4.plugins
 
 import com.google.inject.Binder
+import jakarta.inject.Qualifier
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.guice.KSetMultibinderHelper
 import net.navatwo.kaff4.model.rdf.Aff4RdfModel
 import net.navatwo.kaff4.model.rdf.CompressionMethod
 import net.navatwo.kaff4.rdf.RdfRepositoryConfiguration
 import net.navatwo.kaff4.rdf.RdfValueConverter
-import javax.inject.Qualifier
 import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 import kotlin.reflect.KClass

--- a/kaff4-rdf/build.gradle.kts
+++ b/kaff4-rdf/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
   api(project(":kaff4-rdf:kaff4-rdf-api"))
 
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
   api(libs.rdf4j.model.api)
   api(libs.rdf4j.repository.api)
   api(libs.rdf4j.rio.api)

--- a/kaff4-rdf/kaff4-rdf-api/build.gradle.kts
+++ b/kaff4-rdf/kaff4-rdf-api/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
   api(libs.guice)
-  api(libs.javax.inject)
+  api(libs.jakarta.inject.api)
 
   api(libs.rdf4j.model.api)
   api(libs.rdf4j.sail.api)

--- a/kaff4-rdf/kaff4-rdf-api/src/main/kotlin/net/navatwo/kaff4/rdf/RdfValueConverter.kt
+++ b/kaff4-rdf/kaff4-rdf-api/src/main/kotlin/net/navatwo/kaff4/rdf/RdfValueConverter.kt
@@ -1,9 +1,9 @@
 package net.navatwo.kaff4.rdf
 
 import com.google.inject.TypeLiteral
+import jakarta.inject.Inject
 import org.eclipse.rdf4j.model.Value
 import org.eclipse.rdf4j.model.ValueFactory
-import javax.inject.Inject
 
 abstract class RdfValueConverter<T> protected constructor(val types: Set<TypeLiteral<*>>) {
   init {

--- a/kaff4-rdf/kaff4-rdf-memory/build.gradle.kts
+++ b/kaff4-rdf/kaff4-rdf-memory/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
   api(project(":kaff4-plugin"))
 
   implementation(libs.guice)
-  implementation(libs.javax.inject)
+  implementation(libs.jakarta.inject.api)
   implementation(libs.misk.inject)
   implementation(libs.rdf4j.sail.api)
   implementation(libs.rdf4j.sail.memory)

--- a/kaff4-rdf/kaff4-rdf-memory/src/main/kotlin/net/navatwo/kaff4/rdf/MemoryRdfRepositoryConfiguration.kt
+++ b/kaff4-rdf/kaff4-rdf-memory/src/main/kotlin/net/navatwo/kaff4/rdf/MemoryRdfRepositoryConfiguration.kt
@@ -1,9 +1,9 @@
 package net.navatwo.kaff4.rdf
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.sail.Sail
 import org.eclipse.rdf4j.sail.memory.MemoryStore
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class MemoryRdfRepositoryConfiguration @Inject constructor() : RdfRepositoryConfiguration {

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/RdfRepositoryModule.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/RdfRepositoryModule.kt
@@ -1,13 +1,13 @@
 package net.navatwo.kaff4.rdf
 
 import com.google.inject.Provides
+import jakarta.inject.Singleton
 import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.guice.assistedFactoryModule
 import net.navatwo.guice.key
 import net.navatwo.guice.to
 import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.repository.sail.SailRepository
-import javax.inject.Singleton
 
 object RdfRepositoryModule : KAff4AbstractModule() {
   override fun configure() {

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/RealRdfExecutor.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/RealRdfExecutor.kt
@@ -1,9 +1,9 @@
 package net.navatwo.kaff4.rdf
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.repository.RepositoryConnection
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private val currentConnection: ThreadLocal<QueryableRdfConnection?> = ThreadLocal.withInitial { null }
 

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RdfAnnotationTypeInfo.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RdfAnnotationTypeInfo.kt
@@ -2,6 +2,8 @@ package net.navatwo.kaff4.rdf.io
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.google.common.collect.ImmutableMultimap
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.kaff4.model.dialect.ToolDialect
 import net.navatwo.kaff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import net.navatwo.kaff4.model.rdf.annotations.RdfSubject
@@ -9,8 +11,6 @@ import net.navatwo.kaff4.model.rdf.annotations.RdfValue
 import net.navatwo.kaff4.rdf.NamespacesProvider
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.Resource
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RdfModelParserModule.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RdfModelParserModule.kt
@@ -1,5 +1,6 @@
 package net.navatwo.kaff4.rdf.io
 
+import jakarta.inject.Inject
 import misk.scope.ActionScoped
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
@@ -7,7 +8,6 @@ import net.navatwo.guice.KAff4AbstractModule
 import net.navatwo.guice.assistedFactoryModule
 import net.navatwo.kaff4.model.dialect.ToolDialect
 import net.navatwo.kaff4.rdf.io.literals.RdfLiteralConvertersModule
-import javax.inject.Inject
 
 object RdfModelParserModule : KAff4AbstractModule() {
   override fun configure() {

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RdfValueConverterProvider.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RdfValueConverterProvider.kt
@@ -1,7 +1,7 @@
 package net.navatwo.kaff4.rdf.io
 
+import jakarta.inject.Inject
 import net.navatwo.kaff4.rdf.RdfValueConverter
-import javax.inject.Inject
 
 internal class RdfValueConverterProvider @Inject constructor(
   private val converters: Set<RdfValueConverter<*>>,

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RealRdfModelParser.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/RealRdfModelParser.kt
@@ -1,10 +1,10 @@
 package net.navatwo.kaff4.rdf.io
 
+import jakarta.inject.Inject
 import misk.scope.ActionScoped
 import net.navatwo.kaff4.rdf.QueryableRdfConnection
 import org.eclipse.rdf4j.model.Resource
 import org.eclipse.rdf4j.model.Statement
-import javax.inject.Inject
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/BigIntegerRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/BigIntegerRdfConverter.kt
@@ -1,12 +1,12 @@
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.Value
 import java.math.BigInteger
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class BigIntegerRdfConverter @Inject constructor() :

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/DoubleRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/DoubleRdfConverter.kt
@@ -2,9 +2,9 @@
 
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.model.Literal
-import javax.inject.Inject
-import javax.inject.Singleton
 import java.lang.Double as JDouble
 
 @Singleton

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/EnumRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/EnumRdfConverter.kt
@@ -1,10 +1,10 @@
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.RdfValueConverter
 import org.eclipse.rdf4j.model.Value
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class EnumRdfConverter @Inject constructor(

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/FloatRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/FloatRdfConverter.kt
@@ -2,9 +2,9 @@
 
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.model.Literal
-import javax.inject.Inject
-import javax.inject.Singleton
 import java.lang.Float as JFloat
 
 @Singleton

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/IntRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/IntRdfConverter.kt
@@ -2,9 +2,9 @@
 
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.model.Literal
-import javax.inject.Inject
-import javax.inject.Singleton
 import java.lang.Integer as JInt
 
 @Singleton

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/IriRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/IriRdfConverter.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.Value
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class IriRdfConverter @Inject constructor() : ConcreteRdfValueConverter<IRI>(typeLiteral<IRI>()) {

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/LongRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/LongRdfConverter.kt
@@ -2,9 +2,9 @@
 
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.model.Literal
-import javax.inject.Inject
-import javax.inject.Singleton
 import java.lang.Long as JLong
 
 @Singleton

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/ResourceRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/ResourceRdfConverter.kt
@@ -1,11 +1,11 @@
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import org.eclipse.rdf4j.model.Resource
 import org.eclipse.rdf4j.model.Value
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class ResourceRdfConverter @Inject constructor() :

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/StringRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/StringRdfConverter.kt
@@ -2,9 +2,9 @@
 
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import org.eclipse.rdf4j.model.Literal
-import javax.inject.Inject
-import javax.inject.Singleton
 import java.lang.String as JString
 
 @Singleton

--- a/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/ZonedDateTimeRdfConverter.kt
+++ b/kaff4-rdf/src/main/kotlin/net/navatwo/kaff4/rdf/io/literals/ZonedDateTimeRdfConverter.kt
@@ -1,12 +1,12 @@
 package net.navatwo.kaff4.rdf.io.literals
 
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import net.navatwo.guice.typeLiteral
 import net.navatwo.kaff4.rdf.io.ConcreteRdfValueConverter
 import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.Value
 import java.time.ZonedDateTime
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 internal class ZonedDateTimeRdfConverter @Inject constructor() :

--- a/kaff4-rdf/src/test/kotlin/net/navatwo/kaff4/rdf/RealRdfExecutorTest.kt
+++ b/kaff4-rdf/src/test/kotlin/net/navatwo/kaff4/rdf/RealRdfExecutorTest.kt
@@ -1,6 +1,7 @@
 package net.navatwo.kaff4.rdf
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
 import net.navatwo.kaff4.Aff4CoreModule
 import net.navatwo.kaff4.TestActionScopeModule
 import net.navatwo.kaff4.container.Aff4ImageOpenerModule
@@ -13,7 +14,6 @@ import org.assertj.core.api.ObjectAssert
 import org.eclipse.rdf4j.model.Statement
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 internal class RealRdfExecutorTest {
   @GuiceModule

--- a/kaff4-rdf/src/test/kotlin/net/navatwo/kaff4/rdf/io/RdfModelParserTest.kt
+++ b/kaff4-rdf/src/test/kotlin/net/navatwo/kaff4/rdf/io/RdfModelParserTest.kt
@@ -3,6 +3,9 @@
 package net.navatwo.kaff4.rdf.io
 
 import com.google.inject.util.Modules
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import jakarta.inject.Singleton
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
 import net.navatwo.guice.KAff4AbstractModule
@@ -28,9 +31,6 @@ import org.eclipse.rdf4j.model.Value
 import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 import kotlin.Long
 import java.lang.Integer as JInteger
 import java.lang.Long as JLong


### PR DESCRIPTION
Ports to `jakarta.inject` as per [Jakarta EE](https://jakarta.ee/blogs/javax-jakartaee-namespace-ecosystem-progress/). This unblockes Guice 7.0.0.